### PR TITLE
MAJI-82 add email sending action in admin panel

### DIFF
--- a/django_nitro_mailer/admin.py
+++ b/django_nitro_mailer/admin.py
@@ -1,11 +1,40 @@
 from django.contrib import admin
-
+from django.shortcuts import redirect
+from django.contrib import messages
+from django.urls import path
+from django.utils.html import format_html
+from django.urls import reverse
 from django_nitro_mailer.forms import EmailAdminForm
 from django_nitro_mailer.models import Email
+from django_nitro_mailer.tasks import send_emails
 
 
 @admin.register(Email)
 class EmailAdmin(admin.ModelAdmin):
     form = EmailAdminForm
 
-    list_display = ("subject", "recipients", "created_at", "priority")
+    def get_urls(self):
+        urls = super().get_urls()
+        custom_urls = [
+            path(
+                "send-email/<int:email_id>/",
+                self.admin_site.admin_view(self.send_email),
+                name="send_email",
+            ),
+        ]
+        return custom_urls + urls
+
+    def send_email(self, request, email_id):
+        try:
+            email = Email.objects.filter(id=email_id)
+            send_emails(queryset=email)
+            messages.success(request, "Email has been sent.")
+        except Exception as e:
+            messages.error(request, f"Error while sending email: {e}")
+        return redirect(request.META.get("HTTP_REFERER", "admin:index"))
+
+    def email_action_button(self, obj):
+        url = reverse("admin:send_email", args=[obj.pk])
+        return format_html('<a class="button" href="{}">Send email</a>', url)
+
+    list_display = ("subject", "recipients", "created_at", "priority", "email_action_button")

--- a/django_nitro_mailer/admin.py
+++ b/django_nitro_mailer/admin.py
@@ -11,7 +11,10 @@ from django_nitro_mailer.tasks import send_emails
 
 @admin.register(Email)
 class EmailAdmin(admin.ModelAdmin):
+    change_form_template = "admin/email_change_form.html"
+
     form = EmailAdminForm
+    list_display = ("subject", "recipients", "created_at", "priority")
 
     def get_urls(self):
         urls = super().get_urls()
@@ -32,9 +35,3 @@ class EmailAdmin(admin.ModelAdmin):
         except Exception as e:
             messages.error(request, f"Error while sending email: {e}")
         return redirect(request.META.get("HTTP_REFERER", "admin:index"))
-
-    def email_action_button(self, obj):
-        url = reverse("admin:send_email", args=[obj.pk])
-        return format_html('<a class="button" href="{}">Send email</a>', url)
-
-    list_display = ("subject", "recipients", "created_at", "priority", "email_action_button")

--- a/django_nitro_mailer/admin.py
+++ b/django_nitro_mailer/admin.py
@@ -2,11 +2,19 @@ from django.contrib import admin
 from django.shortcuts import redirect
 from django.contrib import messages
 from django.urls import path
-from django.utils.html import format_html
-from django.urls import reverse
 from django_nitro_mailer.forms import EmailAdminForm
 from django_nitro_mailer.models import Email
 from django_nitro_mailer.tasks import send_emails
+
+
+@admin.action(description="Send selected emails")
+def send_selected_emails(modeladmin, request, queryset):
+    try:
+        count = queryset.count()
+        send_emails(queryset)
+        messages.success(request, "Successfully sent %s email(s)." % count)
+    except Exception as e:
+        messages.error(request, "An error occurred while sending emails: %s" % e)
 
 
 @admin.register(Email)
@@ -15,6 +23,7 @@ class EmailAdmin(admin.ModelAdmin):
 
     form = EmailAdminForm
     list_display = ("subject", "recipients", "created_at", "priority")
+    actions = [send_selected_emails]
 
     def get_urls(self):
         urls = super().get_urls()

--- a/django_nitro_mailer/forms.py
+++ b/django_nitro_mailer/forms.py
@@ -16,6 +16,7 @@ class EmailAdminForm(forms.ModelForm):
     context = forms.JSONField(
         required=False, initial={}, help_text=gettext_lazy("JSON context for rendering the email content.")
     )
+    send_email = forms.BooleanField(required=False, initial=False, widget=forms.HiddenInput())
 
     def __init__(self: Self, *args: Any, **kwargs: Any) -> None:
         if instance := kwargs.get("instance", None):

--- a/django_nitro_mailer/forms.py
+++ b/django_nitro_mailer/forms.py
@@ -16,7 +16,6 @@ class EmailAdminForm(forms.ModelForm):
     context = forms.JSONField(
         required=False, initial={}, help_text=gettext_lazy("JSON context for rendering the email content.")
     )
-    send_email = forms.BooleanField(required=False, initial=False, widget=forms.HiddenInput())
 
     def __init__(self: Self, *args: Any, **kwargs: Any) -> None:
         if instance := kwargs.get("instance", None):

--- a/django_nitro_mailer/templates/admin/email_change_form.html
+++ b/django_nitro_mailer/templates/admin/email_change_form.html
@@ -1,0 +1,8 @@
+{% extends "admin/change_form.html" %}
+
+{% block object-tools-items %}
+    <li>
+        <a href="{% url 'admin:send_email' original.pk %}">Send Email</a>
+    </li>
+    {{ block.super }}
+{% endblock object-tools-items %}


### PR DESCRIPTION
wiem że rozwiązanie email = Email.objects.filter(id=email_id) nie jest idealne ale nie miałam lepszego pomysłu, żeby nie zmieniać funkcji send_emails(queryset=email), w której używamy .select_for_update() i nie można było przekazać jednego maila 